### PR TITLE
fix to not assume single line assertion

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function(expr, msg){
       var col = callsite.getColumnNumber() - 1;
       var src = getScript(file);
       line = src.split('\n')[line].slice(col);
-      expr = line.match(/assert\((.*)\)/)[1].trim();
+      expr = line.match(/assert\((.*?)[\)|$]/)[1].trim();
       msg = expr;
     } else {
       msg = 'assertion failed';


### PR DESCRIPTION
case:

``` js
assert(fn({
  prop: true
}));
```

otherwise it errors out on the `[1]`
