### PR TITLE
pin deps

### DIFF
--- a/component.json
+++ b/component.json
@@ -8,8 +8,8 @@
     "test"
   ],
   "dependencies": {
-    "component/stack": "*",
-    "jkroso/equals": "*",
+    "component/stack": "0.0.1",
+    "jkroso/equals": "1.0.2",
     "yields/fmt": "0.1.0"
   },
   "scripts": [


### PR DESCRIPTION
this pins some `*` deps, because upstream changes to `jkroso/equals` is breaking things.

/cc @ndhoule