### PR TITLE
upgrade to  to 1.0.4 which pins a version of jkroso/equals

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,9 @@
 
+0.5.4 / 2016-05-27
+==================
+
+  * deps: upgrade to `jkroso/assert` to 1.0.4 which pins a version of jkroso/equals
+
 0.5.3 / 2016-05-23
 ==================
 

--- a/component.json
+++ b/component.json
@@ -2,14 +2,14 @@
   "name": "assert",
   "repo": "component/assert",
   "description": "Assertion lib",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "keywords": [
     "assert",
     "test"
   ],
   "dependencies": {
     "component/stack": "0.0.1",
-    "jkroso/equals": "1.0.1",
+    "jkroso/equals": "1.0.4",
     "yields/fmt": "0.1.0"
   },
   "scripts": [


### PR DESCRIPTION
Recently jkroso has been upgrading his "equals" and "type" modules. You hit one issue with https://github.com/component/assert/commit/cdd50bda8e1340b94b74ccc7eaf256665f446351#diff-162d38b326426c84ac91e51f931105bb

Another issue is that the "equals" module has a component.json dependency on "type" with version "*" which unfortunately picks up changes from the new 2.x versions. Details here: https://github.com/jkroso/equals/pull/9

jkroso has kindly produced a 1.0.4 version of "equals" that version locks its dependency on on "type". Could you please upgrade to this version and publish a new version of "assert"?
