### PR TITLE
Lock to version 1.0.5 of jkroso/equals that regresses changes back to equivalent of November 2015

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,14 +2,14 @@
   "name": "assert",
   "repo": "component/assert",
   "description": "Assertion lib",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "keywords": [
     "assert",
     "test"
   ],
   "dependencies": {
     "component/stack": "0.0.1",
-    "jkroso/equals": "1.0.4",
+    "jkroso/equals": "1.0.5",
     "yields/fmt": "0.1.0"
   },
   "scripts": [


### PR DESCRIPTION
After testing the changes to jkroso/equals that were merged in https://github.com/component/assert/pull/19 changes to jkroso/equals had to be further rolled back to the equivalent of equals in November 2015; see jkroso/equals#11

Could you please bump assert to use jkroso/equals@1.0.5 and tag a new version of assert?

Many thanks!
